### PR TITLE
Use last version of `vinyl-fs` (~0.1.2) to avoid node-gyp/gaze issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "gulp-util": "~2.2.14",
     "chalk": "~0.4.0",
     "text-table": "~0.2.0",
-    "vinyl-fs": "0.0.2",
+    "vinyl-fs": "~0.1.2",
     "jsdoc": "3.3.0-alpha5",
     "taffydb": "~2.7.2",
     "ink-docstrap": "~0.3.0-0",


### PR DESCRIPTION
Currently configured `vinyl-fs` (**0.0.2**) needs native compilation using `node-gyp` for `gaze` dependency crashing on non-developer/compiler configured machines.
