### PR TITLE
Update to JSDoc 3.3.0-alpha7

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-jsdoc",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "A jsdoc plugin for Gulp",
   "keywords": [
     "gulpplugin",
@@ -36,7 +36,7 @@
     "chalk": "~0.4.0",
     "text-table": "~0.2.0",
     "vinyl-fs": "~0.1.2",
-    "jsdoc": "3.3.0-alpha5",
+    "jsdoc": "^3.3.0-alpha7",
     "taffydb": "~2.7.2",
     "ink-docstrap": "~0.3.0-0",
     "wrench": "~1.5.6",


### PR DESCRIPTION
To solve for a known issue (jsdoc3/jsdoc#519) with installing on Windows, please update to the latest published JSDoc where the defect is corrected.
