### PR TITLE
Change jsdoc version from alpha5 for alpha9

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "chalk": "~0.4.0",
     "text-table": "~0.2.0",
     "vinyl-fs": "~0.3.0",
-    "jsdoc": "3.3.0-alpha5",
+    "jsdoc": "3.3.0-alpha9",
     "taffydb": "~2.7.2",
     "ink-docstrap": "~0.4.5",
     "wrench": "~1.5.6",


### PR DESCRIPTION
alpha5 don't refresh members and methods from my class.
