### PR TITLE
Lock docstrap at v0.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "vinyl-fs": "~0.3.0",
     "jsdoc": "3.3.0-alpha5",
     "taffydb": "~2.7.2",
-    "ink-docstrap": "~0.4.5",
+    "ink-docstrap": "git://github.com/terryweiss/docstrap.git#v0.5.0",
     "wrench": "~1.5.6",
     "marked": "~0.3.1"
   },


### PR DESCRIPTION
The latest docstrap is v0.5.2.

On the `publish.js`, it uses `member.interfaces` without checking compatibility.
Therefore, any jsdoc < `v3.3.0-alpha10` would got an render error.

```
TypeError: Cannot read property 'length' of undefined
```

Lock docstrap at v0.5.0 to solve this problem.
