### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "chalk": "~0.4.0",
     "text-table": "~0.2.0",
     "vinyl-fs": "~0.3.0",
-    "jsdoc": "3.3.0-alpha5",
+    "jsdoc": "3.4.0",
     "taffydb": "~2.7.2",
     "ink-docstrap": "~0.4.5",
     "wrench": "~1.5.6",


### PR DESCRIPTION
npm install failing due to jsdoc version 3.3.0-alpha5. Updated to jsdoc 3.4.0 , which is stable version. Check and merge as soon as possible.

Error: Invalid Package: expected taffydb but found taffydb-jsdoc
